### PR TITLE
Fixed linking to 'listings' Page

### DIFF
--- a/templates/pages/about.html
+++ b/templates/pages/about.html
@@ -63,7 +63,7 @@
     <h2 class="display-4">We Work For You</h2>
     <h4>Lorem ipsum dolor sit amet consectetur adipisicing elit. Autem velit aperiam, unde aliquid at similique!</h4>
     <hr>
-    <a href="listings.html" class="btn btn-secondary text-white btn-lg">View Our Featured Listings</a>
+    <a href="{% url 'listings' %}" class="btn btn-secondary text-white btn-lg">View Our Featured Listings</a>
   </section>
 
   <!-- Team -->


### PR DESCRIPTION
un-used jinja syntax during referring to listings